### PR TITLE
rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-17.0.6-stage2-attempt-4"
+staging_channel_upload_target: llvm-17.0.6-verify-2
+channels:
+  - llvm-17.0.6-verify-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-staging_channel_upload_target: llvm-17.0.6-verify-2
-channels:
-  - https://staging.continuum.io/prefect/lllvm-17.0.6-verify-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 staging_channel_upload_target: llvm-17.0.6-verify-2
 channels:
-  - llvm-17.0.6-verify-2
+  - https://staging.continuum.io/prefect/lllvm-17.0.6-verify-2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - patches/0001-Support-legacy-standalone-builds.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   
   # Prevent mixing with GNU's implementation
@@ -44,8 +44,8 @@ requirements:
     - m2-patch                # [win]
     - llvm
   host:
-    - clangdev {{ bootstrap_version }}  # [not osx]
-    - llvm {{ bootstrap_version }}      # [not osx]
+    - clangdev {{ version }}  # [not osx]
+    - llvm {{ version }}      # [not osx]
 
 outputs:
 
@@ -62,8 +62,10 @@ outputs:
       run:
         - {{ pin_subpackage("libcxx", exact=True) }}
       run_constrained:
-        - clang {{ bootstrap_version }}
-        - llvm {{ bootstrap_version }}
+        - clang {{ version }}
+        - llvm {{ version }}
+        - llvm-openmp  {{ version }}
+        - llvm-tools  {{ version }}
 
     test:
       requires:
@@ -71,7 +73,7 @@ outputs:
         - clangxx
         - ld64                   # [osx]
         - cctools                # [osx]
-        - llvmdev {{ bootstrap_version }}  # [osx]
+        - llvmdev {{ version }}  # [osx]
         - llvm-tools             # [osx]
         - {{ compiler('cxx') }}   # [not linux]
         - {{ compiler('c') }}     # [not linux]
@@ -124,8 +126,10 @@ outputs:
       run:
         - {{ pin_subpackage("libcxxabi", exact=True) }}    # [linux]
       run_constrained:
-        - clang {{ bootstrap_version }}
-        - llvm {{ bootstrap_version }}
+        - clang {{ version }}
+        - llvm {{ version }}
+        - llvm-openmp  {{ version }}
+        - llvm-tools  {{ version }}
     test:
       commands:
         # presence of shared libraries


### PR DESCRIPTION
libcxx rebuild

**Destination channel:**  defaults

### Explanation of changes:

- Add llvm-openmp  and llvm-tools to run_contrained
- Bump build number
- Use `{{ version }}` instead of misleading `{{ bootstrap_version }}`
