### PR TITLE
Fix ABI break introduced by switching to _LIBCPP_COMPRESSED_PAIR

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,11 @@ export CFLAGS="$CFLAGS -I$LLVM_PREFIX/include -I$BUILD_PREFIX/include"
 export LDFLAGS="$LDFLAGS -L$LLVM_PREFIX/lib -Wl,-rpath,$LLVM_PREFIX/lib -L$BUILD_PREFIX/lib -Wl,-rpath,$BUILD_PREFIX/lib"
 export PATH="$LLVM_PREFIX/bin:$PATH"
 
+# On Linux, explicitly use Clang compilers to avoid GCC warning flag issues
+if [[ "$target_platform" == linux-* ]]; then
+    export CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+fi
+
 mkdir build
 
 cmake -G Ninja \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,10 @@ source:
       - patches/0002-Work-around-stray-nostdlib-flags-causing-errors-with.patch  # [osx]
       # allow chrono implementation to work on osx
       - patches/0003-patch-__libcpp_tzdb_directory-to-allow-use-on-osx.patch  # [osx]
+      - patches/0004-fix-abi-break.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   
   # Prevent mixing with GNU's implementation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,6 @@ requirements:
     - {{ stdlib('c') }}
     - clangxx                 # [linux]
     - clang                   # [linux]
-    - python                  # [not osx]
     - llvm
   host:
     - clangdev {{ bootstrap_version }}  # [not osx]

--- a/recipe/patches/0004-fix-abi-break.patch
+++ b/recipe/patches/0004-fix-abi-break.patch
@@ -1,0 +1,243 @@
+From 0c5029c3ad5a2c1fd8dddbc8055698207ce7ac20 Mon Sep 17 00:00:00 2001
+From: Nikolas Klauser <nikolasklauser@berlin.de>
+Date: Thu, 21 Aug 2025 09:26:19 +0200
+Subject: [PATCH] [libc++] Fix ABI break introduced by switching to
+ _LIBCPP_COMPRESSED_PAIR
+
+Update libcxx/docs/ReleaseNotes/21.rst
+
+Co-authored-by: Louis Dionne <ldionne.2@gmail.com>
+---
+ libcxx/include/__memory/compressed_pair.h     | 54 +++++++++++++------
+ libcxx/include/string                         | 14 ++++-
+ .../unord.map/abi.compile.pass.cpp            | 14 +++--
+ .../unord.set/abi.compile.pass.cpp            | 12 ++++-
+ .../unique.ptr.ctor/default.pass.cpp          |  4 ++
+ .../unique.ptr.ctor/nullptr.pass.cpp          |  4 ++
+ .../unique.ptr.ctor/pointer.pass.cpp          |  4 ++
+ 7 files changed, 83 insertions(+), 23 deletions(-)
+
+diff --git a/libcxx/include/__memory/compressed_pair.h b/libcxx/include/__memory/compressed_pair.h
+index 38798a21fa3c..4d66b4019e29 100644
+--- a/libcxx/include/__memory/compressed_pair.h
++++ b/libcxx/include/__memory/compressed_pair.h
+@@ -73,21 +73,45 @@ class __compressed_pair_padding {
+ template <class _ToPad>
+ class __compressed_pair_padding<_ToPad, true> {};
+ 
+-#  define _LIBCPP_COMPRESSED_PAIR(T1, Initializer1, T2, Initializer2)                                                  \
+-    _LIBCPP_NO_UNIQUE_ADDRESS __attribute__((__aligned__(::std::__compressed_pair_alignment<T2>))) T1 Initializer1;    \
+-    _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);          \
+-    _LIBCPP_NO_UNIQUE_ADDRESS T2 Initializer2;                                                                         \
+-    _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T2> _LIBCPP_CONCAT3(__padding2_, __LINE__, _)
+-
+-#  define _LIBCPP_COMPRESSED_TRIPLE(T1, Initializer1, T2, Initializer2, T3, Initializer3)                              \
+-    _LIBCPP_NO_UNIQUE_ADDRESS                                                                                          \
+-    __attribute__((__aligned__(::std::__compressed_pair_alignment<T2>),                                                \
+-                   __aligned__(::std::__compressed_pair_alignment<T3>))) T1 Initializer1;                              \
+-    _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);          \
+-    _LIBCPP_NO_UNIQUE_ADDRESS T2 Initializer2;                                                                         \
+-    _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T2> _LIBCPP_CONCAT3(__padding2_, __LINE__, _);          \
+-    _LIBCPP_NO_UNIQUE_ADDRESS T3 Initializer3;                                                                         \
+-    _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T3> _LIBCPP_CONCAT3(__padding3_, __LINE__, _)
++// TODO: Fix the ABI for GCC as well once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121637 is fixed
++#  ifdef _LIBCPP_COMPILER_GCC
++#    define _LIBCPP_COMPRESSED_PAIR(T1, Initializer1, T2, Initializer2)                                                \
++      _LIBCPP_NO_UNIQUE_ADDRESS __attribute__((__aligned__(::std::__compressed_pair_alignment<T2>))) T1 Initializer1;  \
++      _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);        \
++      _LIBCPP_NO_UNIQUE_ADDRESS T2 Initializer2;                                                                       \
++      _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T2> _LIBCPP_CONCAT3(__padding2_, __LINE__, _)
++
++#    define _LIBCPP_COMPRESSED_TRIPLE(T1, Initializer1, T2, Initializer2, T3, Initializer3)                            \
++      _LIBCPP_NO_UNIQUE_ADDRESS                                                                                        \
++      __attribute__((__aligned__(::std::__compressed_pair_alignment<T2>),                                              \
++                     __aligned__(::std::__compressed_pair_alignment<T3>))) T1 Initializer1;                            \
++      _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);        \
++      _LIBCPP_NO_UNIQUE_ADDRESS T2 Initializer2;                                                                       \
++      _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T2> _LIBCPP_CONCAT3(__padding2_, __LINE__, _);        \
++      _LIBCPP_NO_UNIQUE_ADDRESS T3 Initializer3;                                                                       \
++      _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T3> _LIBCPP_CONCAT3(__padding3_, __LINE__, _)
++#  else
++#    define _LIBCPP_COMPRESSED_PAIR(T1, Initializer1, T2, Initializer2)                                                \
++      struct {                                                                                                         \
++        _LIBCPP_NO_UNIQUE_ADDRESS                                                                                      \
++        __attribute__((__aligned__(::std::__compressed_pair_alignment<T2>))) T1 Initializer1;                          \
++        _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);      \
++        _LIBCPP_NO_UNIQUE_ADDRESS T2 Initializer2;                                                                     \
++        _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T2> _LIBCPP_CONCAT3(__padding2_, __LINE__, _);      \
++      }
++
++#    define _LIBCPP_COMPRESSED_TRIPLE(T1, Initializer1, T2, Initializer2, T3, Initializer3)                            \
++      struct {                                                                                                         \
++        _LIBCPP_NO_UNIQUE_ADDRESS                                                                                      \
++        __attribute__((__aligned__(::std::__compressed_pair_alignment<T2>),                                            \
++                       __aligned__(::std::__compressed_pair_alignment<T3>))) T1 Initializer1;                          \
++        _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);      \
++        _LIBCPP_NO_UNIQUE_ADDRESS T2 Initializer2;                                                                     \
++        _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T2> _LIBCPP_CONCAT3(__padding2_, __LINE__, _);      \
++        _LIBCPP_NO_UNIQUE_ADDRESS T3 Initializer3;                                                                     \
++        _LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T3> _LIBCPP_CONCAT3(__padding3_, __LINE__, _);      \
++      }
++#  endif
+ 
+ #else
+ #  define _LIBCPP_COMPRESSED_PAIR(T1, Name1, T2, Name2)                                                                \
+diff --git a/libcxx/include/string b/libcxx/include/string
+index fdd8085106dc..50782493c8bd 100644
+--- a/libcxx/include/string
++++ b/libcxx/include/string
+@@ -1005,7 +1005,12 @@ public:
+ 
+   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string()
+       _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
+-      : __rep_() {
++#  if _LIBCPP_STD_VER >= 20 // TODO(LLVM 23): Remove this condition; this is a workaround for https://llvm.org/PR154567
++      : __rep_(__short())
++#  else
++      : __rep_()
++#  endif
++  {
+     __annotate_new(0);
+   }
+ 
+@@ -1015,7 +1020,12 @@ public:
+ #  else
+       _NOEXCEPT
+ #  endif
+-      : __rep_(), __alloc_(__a) {
++#  if _LIBCPP_STD_VER >= 20 // TODO(LLVM 23): Remove this condition; this is a workaround for https://llvm.org/PR154567
++      : __rep_(__short()),
++#  else
++      : __rep_(),
++#  endif
++        __alloc_(__a) {
+     __annotate_new(0);
+   }
+ 
+diff --git a/libcxx/test/libcxx/containers/associative/unord.map/abi.compile.pass.cpp b/libcxx/test/libcxx/containers/associative/unord.map/abi.compile.pass.cpp
+index 55d42a8d017e..c5c030b5eb3b 100644
+--- a/libcxx/test/libcxx/containers/associative/unord.map/abi.compile.pass.cpp
++++ b/libcxx/test/libcxx/containers/associative/unord.map/abi.compile.pass.cpp
+@@ -12,8 +12,6 @@
+ // unordered containers changes when bounded unique_ptr is enabled.
+ // UNSUPPORTED: libcpp-has-abi-bounded-unique_ptr
+ 
+-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+-
+ #include <cstdint>
+ #include <unordered_map>
+ 
+@@ -98,9 +96,12 @@ static_assert(TEST_ALIGNOF(unordered_map_alloc<char, final_small_iter_allocator<
+ 
+ struct TEST_ALIGNAS(32) AlignedHash {};
+ struct UnalignedEqualTo {};
+-
+-// This part of the ABI has been broken between LLVM 19 and LLVM 20.
++// TODO: Fix the ABI for GCC as well once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121637 is fixed
++#  ifdef TEST_COMPILER_GCC
+ static_assert(sizeof(std::unordered_map<int, int, AlignedHash, UnalignedEqualTo>) == 64, "");
++#  else
++static_assert(sizeof(std::unordered_map<int, int, AlignedHash, UnalignedEqualTo>) == 96, "");
++#  endif
+ static_assert(TEST_ALIGNOF(std::unordered_map<int, int, AlignedHash, UnalignedEqualTo>) == 32, "");
+ 
+ #elif __SIZE_WIDTH__ == 32
+@@ -133,7 +134,12 @@ static_assert(TEST_ALIGNOF(unordered_map_alloc<char, final_small_iter_allocator<
+ struct TEST_ALIGNAS(32) AlignedHash {};
+ struct UnalignedEqualTo {};
+ 
++// TODO: Fix the ABI for GCC as well once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121637 is fixed
++#  ifdef TEST_COMPILER_GCC
+ static_assert(sizeof(std::unordered_map<int, int, AlignedHash, UnalignedEqualTo>) == 64);
++#  else
++static_assert(sizeof(std::unordered_map<int, int, AlignedHash, UnalignedEqualTo>) == 96);
++#  endif
+ static_assert(TEST_ALIGNOF(std::unordered_map<int, int, AlignedHash, UnalignedEqualTo>) == 32);
+ 
+ #else
+diff --git a/libcxx/test/libcxx/containers/associative/unord.set/abi.compile.pass.cpp b/libcxx/test/libcxx/containers/associative/unord.set/abi.compile.pass.cpp
+index bee2012bbea2..0efc85418083 100644
+--- a/libcxx/test/libcxx/containers/associative/unord.set/abi.compile.pass.cpp
++++ b/libcxx/test/libcxx/containers/associative/unord.set/abi.compile.pass.cpp
+@@ -12,7 +12,6 @@
+ // unordered containers changes when bounded unique_ptr is enabled.
+ // UNSUPPORTED: libcpp-has-abi-bounded-unique_ptr
+ 
+-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+ 
+ #include <cstdint>
+ #include <unordered_set>
+@@ -98,8 +97,12 @@ static_assert(TEST_ALIGNOF(unordered_set_alloc<char, final_small_iter_allocator<
+ struct TEST_ALIGNAS(32) AlignedHash {};
+ struct UnalignedEqualTo {};
+ 
+-// This part of the ABI has been broken between LLVM 19 and LLVM 20.
++// TODO: Fix the ABI for GCC as well once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121637 is fixed
++#  ifdef TEST_COMPILER_GCC
+ static_assert(sizeof(std::unordered_set<int, AlignedHash, UnalignedEqualTo>) == 64, "");
++#  else
++static_assert(sizeof(std::unordered_set<int, AlignedHash, UnalignedEqualTo>) == 96, "");
++#  endif
+ static_assert(TEST_ALIGNOF(std::unordered_set<int, AlignedHash, UnalignedEqualTo>) == 32, "");
+ 
+ #elif __SIZE_WIDTH__ == 32
+@@ -131,7 +134,12 @@ static_assert(TEST_ALIGNOF(unordered_set_alloc<char, final_small_iter_allocator<
+ struct TEST_ALIGNAS(32) AlignedHash {};
+ struct UnalignedEqualTo {};
+ 
++// TODO: Fix the ABI for GCC as well once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121637 is fixed
++#  ifdef TEST_COMPILER_GCC
+ static_assert(sizeof(std::unordered_set<int, AlignedHash, UnalignedEqualTo>) == 64);
++#  else
++static_assert(sizeof(std::unordered_set<int, AlignedHash, UnalignedEqualTo>) == 96);
++#  endif
+ static_assert(TEST_ALIGNOF(std::unordered_set<int, AlignedHash, UnalignedEqualTo>) == 32);
+ 
+ #else
+diff --git a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
+index 7f4c90922d6c..e2abfd17d27c 100644
+--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
++++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
+@@ -82,6 +82,10 @@ TEST_CONSTEXPR_CXX23 bool test_basic() {
+     p.get_deleter().set_state(5);
+     assert(p.get_deleter().state() == 5);
+   }
++// TODO: Remove this check once https://llvm.org/PR154567 is fixed
++#if TEST_STD_VER >= 23 && defined(TEST_COMPILER_CLANG)
++  if (!TEST_IS_CONSTANT_EVALUATED)
++#endif
+   {
+     std::unique_ptr<ElemType, DefaultCtorDeleter<ElemType> > p;
+     assert(p.get() == 0);
+diff --git a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
+index 45017a03b95d..f5e0541684d1 100644
+--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
++++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
+@@ -47,6 +47,10 @@ TEST_CONSTEXPR_CXX23 void test_basic() {
+     assert(p.get() == 0);
+     assert(p.get_deleter().state() == 0);
+   }
++// TODO: Remove this check once https://llvm.org/PR154567 is fixed
++#if TEST_STD_VER >= 23 && defined(TEST_COMPILER_CLANG)
++  if (!TEST_IS_CONSTANT_EVALUATED)
++#endif
+   {
+     std::unique_ptr<VT, DefaultCtorDeleter<VT> > p(nullptr);
+     assert(p.get() == 0);
+diff --git a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
+index cbce5c9c74c5..e9912d4574af 100644
+--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
++++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
+@@ -75,6 +75,10 @@ TEST_CONSTEXPR_CXX23 void test_pointer() {
+   }
+   if (!TEST_IS_CONSTANT_EVALUATED)
+     assert(A::count == 0);
++// TODO: Remove this check once https://llvm.org/PR154567 is fixed
++#if TEST_STD_VER >= 23 && defined(TEST_COMPILER_CLANG)
++  if (!TEST_IS_CONSTANT_EVALUATED)
++#endif
+   {
+     A* p = newValue<ValueT>(expect_alive);
+     if (!TEST_IS_CONSTANT_EVALUATED)
+-- 
+2.45.2


### PR DESCRIPTION
libcxx v20.1.8 rebuild

**Destination channel:**  defaults

### Links

- [PKG-9707](https://anaconda.atlassian.net/browse/PKG-9707) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-20.1.8)

### Explanation of changes:

- ...


[PKG-9707]: https://anaconda.atlassian.net/browse/PKG-9707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ