### PR TITLE
loosen constraints

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,13 @@ set -ex
 
 LLVM_PREFIX=$PREFIX
 
+# On Linux, explicitly use Clang compilers to avoid GCC warning flag issues
+# todo: switch back to gcc when we have a recent enough version
+# https://libcxx.llvm.org/index.html#platform-and-compiler-support
+if [[ "$target_platform" == linux-* ]]; then
+    export CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+fi
+
 if [[ "$target_platform" == osx-* ]]; then
     export CFLAGS="$CFLAGS -isysroot $CONDA_BUILD_SYSROOT"
     export CXXFLAGS="$CXXFLAGS -isysroot $CONDA_BUILD_SYSROOT"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,15 +73,10 @@ outputs:
       run:
         - tzdata
         - {{ pin_subpackage("libcxx", max_pin=None) }}
-        - libcxx >={{ version }},<{{ major + 2 }}
-      run_constrained:
         # The runtime support tools' APIs with the LibCXX libraries will 
         # generally remain forwards and backwards compatible, for at least 
         # one major release. https://www.libcxx.org/INSTALL.html
-        - clang >={{ major }},<{{ major + 2 }}
-        - llvm >={{ major }},<{{ major + 2 }}
-        - llvm-openmp  >={{ major }},<{{ major + 2 }}
-        - llvm-tools  >={{ major }},<{{ major + 2 }}
+        - libcxx >={{ version }},<{{ major + 2 }}
 
     test:
       requires:
@@ -144,14 +139,6 @@ outputs:
         - {{ pin_subpackage("libcxxabi", exact=True) }}    # [linux]
       run:
         - {{ pin_subpackage("libcxxabi", exact=True) }}    # [linux]
-      run_constrained:
-        # The runtime support tools' APIs with the LibCXX libraries will 
-        # generally remain forwards and backwards compatible, for at least 
-        # one major release. https://www.libcxx.org/INSTALL.html
-        - clang >={{ major }},<{{ major + 2 }}
-        - llvm >={{ major }},<{{ major + 2 }}
-        - llvm-openmp  >={{ major }},<{{ major + 2 }}
-        - llvm-tools  >={{ major }},<{{ major + 2 }}
     test:
       commands:
         # Test for versioned runtime libraries

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "20.1.8" %}
-{% set major = version.split(".")[0] %}
+{% set major = version.split(".")[0]|int %}
 
 {% set bootstrap_version = "20.1.8" %}
 
@@ -20,7 +20,7 @@ source:
       - patches/0003-patch-__libcpp_tzdb_directory-to-allow-use-on-osx.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   
   # Prevent mixing with GNU's implementation
@@ -73,12 +73,16 @@ outputs:
         - {{ pin_subpackage("libcxx", exact=True) }}
       run:
         - tzdata
-        - {{ pin_subpackage("libcxx", exact=True) }}
+        - {{ pin_subpackage("libcxx", max_pin=None) }}
+        - libcxx >={{ version }},<{{ major + 2 }}
       run_constrained:
-        - clang {{ version }}
-        - llvm {{ version }}
-        - llvm-openmp  {{ version }}
-        - llvm-tools  {{ version }}
+        # The runtime support tools' APIs with the LibCXX libraries will 
+        # generally remain forwards and backwards compatible, for at least 
+        # one major release. https://www.libcxx.org/INSTALL.html
+        - clang >={{ major }},<{{ major + 2 }}
+        - llvm >={{ major }},<{{ major + 2 }}
+        - llvm-openmp  >={{ major }},<{{ major + 2 }}
+        - llvm-tools  >={{ major }},<{{ major + 2 }}
 
     test:
       requires:
@@ -142,10 +146,13 @@ outputs:
       run:
         - {{ pin_subpackage("libcxxabi", exact=True) }}    # [linux]
       run_constrained:
-        - clang {{ version }}
-        - llvm {{ version }}
-        - llvm-openmp  {{ version }}
-        - llvm-tools  {{ version }}
+        # The runtime support tools' APIs with the LibCXX libraries will 
+        # generally remain forwards and backwards compatible, for at least 
+        # one major release. https://www.libcxx.org/INSTALL.html
+        - clang >={{ major }},<{{ major + 2 }}
+        - llvm >={{ major }},<{{ major + 2 }}
+        - llvm-openmp  >={{ major }},<{{ major + 2 }}
+        - llvm-tools  >={{ major }},<{{ major + 2 }}
     test:
       commands:
         # Test for versioned runtime libraries

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ requirements:
     - {{ stdlib('c') }}
     - clangxx                 # [linux]
     - clang                   # [linux]
-    - python                  # [not osx]
     - llvm
   host:
     - clangdev {{ bootstrap_version }}  # [not osx]


### PR DESCRIPTION
libcxx is mostly abi stable. We can loosen the existing bounds. [libcxx.org/INSTALL.html](https://www.libcxx.org/INSTALL.html)

clangdev itself has constraints on minimum libcxx versions