### PR TITLE
Update to LLVM 21.1.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,10 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0"
+
+staging_channel_upload_target: llvm-21.1.8-stage2-build-0
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,10 +2,6 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-staging_channel_upload_target: llvm-21.1.8-stage2-build-0
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-21.1.8-stage0-build-0
+  - "-c https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0"
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,6 +6,6 @@ build_parameters:
 staging_channel_upload_target: llvm-21.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,6 +6,9 @@ build_parameters:
 staging_channel_upload_target: llvm-21.1.8-stage2-build-0
 
 channels:
+  # Stage 2 channel has clang_bootstrap 21
   - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+  # Stage 0 channel has supporting packages
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,11 +1,11 @@
-# Stage 0: Build libcxx 21.1.8 using LLVM 20 compiler
+# Stage 2: Build libcxx 21.1.8 using LLVM 21 compiler (self-hosted)
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: llvm-21.1.8-stage0-build-0
+staging_channel_upload_target: llvm-21.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0
+  - https://staging.continuum.io/prefect/llvm-21.1.8-stage0-build-0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,14 +1,9 @@
-# Stage 2: Build libcxx 21.1.8 using LLVM 21 compiler (self-hosted)
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: llvm-21.1.8-stage2-build-0
-
+# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
 channels:
-  # Stage 2 channel has clang_bootstrap 21
   - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-  # Stage 0 channel has supporting packages
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,11 @@
+# Stage 0: Build libcxx 21.1.8 using LLVM 20 compiler
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+staging_channel_upload_target: llvm-21.1.8-stage0-build-0
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0
+
+aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,9 +5,10 @@ cxx_compiler:         # [osx]
 
 # libcxx only supports the last released GCC version, see
 # https://libcxx.llvm.org/index.html#platform-and-compiler-support
+# Stage 2: Use LLVM 21 to build libcxx 21 (self-hosted)
 c_compiler_version:
   - 11.2                # [linux]
-  - 20                  # [osx]
+  - 21                  # [osx]
 cxx_compiler_version:
   - 11.2                # [linux]
-  - 20                  # [osx]
+  - 21                  # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,7 +5,6 @@ cxx_compiler:         # [osx]
 
 # libcxx only supports the last released GCC version, see
 # https://libcxx.llvm.org/index.html#platform-and-compiler-support
-# Stage 2: Self-hosted build with clang 21 compiler
 c_compiler_version:
   - 11.2                # [linux]
   - 21                  # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,10 +5,11 @@ cxx_compiler:         # [osx]
 
 # libcxx only supports the last released GCC version, see
 # https://libcxx.llvm.org/index.html#platform-and-compiler-support
-# Stage 2: Use LLVM 21 to build libcxx 21 (self-hosted)
+# Note: Must use LLVM 20 compiler because clang_bootstrap 21 doesn't exist yet
+# (clang_bootstrap is built from clang-compiler-activation, which depends on clangdev 21)
 c_compiler_version:
   - 11.2                # [linux]
-  - 21                  # [osx]
+  - 20                  # [osx]
 cxx_compiler_version:
   - 11.2                # [linux]
-  - 21                  # [osx]
+  - 20                  # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,11 +5,10 @@ cxx_compiler:         # [osx]
 
 # libcxx only supports the last released GCC version, see
 # https://libcxx.llvm.org/index.html#platform-and-compiler-support
-# Note: Must use LLVM 20 compiler because clang_bootstrap 21 doesn't exist yet
-# (clang_bootstrap is built from clang-compiler-activation, which depends on clangdev 21)
+# Stage 2: Self-hosted build with clang 21 compiler
 c_compiler_version:
   - 11.2                # [linux]
-  - 20                  # [osx]
+  - 21                  # [osx]
 cxx_compiler_version:
   - 11.2                # [linux]
-  - 20                  # [osx]
+  - 21                  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -161,6 +161,7 @@ outputs:
     build:
       skip: true  # [not linux]
       missing_dso_whitelist:
+        - lib/libgcc_s.so.1       # [linux]
         - /lib64/libgcc_s.so.1    # [linux]
     files:
       - lib/libc++abi.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -160,6 +160,8 @@ outputs:
   - name: libcxxabi
     build:
       skip: true  # [not linux]
+      missing_dso_whitelist:
+        - /lib64/libgcc_s.so.1    # [linux]
     files:
       - lib/libc++abi.*
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
-{% set version = "20.1.8" %}
+{% set version = "21.1.8" %}
 {% set major = version.split(".")[0]|int %}
 
+# Stage 0: Use LLVM 20 to bootstrap LLVM 21
 {% set bootstrap_version = "20.1.8" %}
 
 
@@ -10,7 +11,7 @@ package:
 
 source:
   - url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-    sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
+    sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
     patches:
       # disable feature that requires up-to-date libcxxabi, which we don't ship
       - patches/0001-disable-_LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPT.patch  # [osx]
@@ -20,7 +21,7 @@ source:
       - patches/0003-patch-__libcpp_tzdb_directory-to-allow-use-on-osx.patch  # [osx]
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   
   # Prevent mixing with GNU's implementation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,7 @@
 {% set version = "21.1.8" %}
 {% set major = version.split(".")[0]|int %}
 
-# Stage 0: Use LLVM 20 to bootstrap LLVM 21
-{% set bootstrap_version = "20.1.8" %}
+{% set bootstrap_version = version %}
 
 
 package:

--- a/recipe/patches/0001-disable-_LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPT.patch
+++ b/recipe/patches/0001-disable-_LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPT.patch
@@ -1,7 +1,7 @@
-From 4bbaf6820bfaf05b5d9f56ccaaddcd83e65fd316 Mon Sep 17 00:00:00 2001
+From 99b1bb1c73ef199f5cbd8e06408665b1fa71e6bb Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 26 May 2024 22:04:04 +1100
-Subject: [PATCH 3/5] disable _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
+Subject: [PATCH 3/6] disable _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
  unconditionally
 
 The required symbols (`___cxa_init_primary_exception` etc.) are in libcxxabi,
@@ -16,10 +16,10 @@ See also https://github.com/llvm/llvm-project/issues/77653 & https://github.com/
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libcxx/include/__configuration/availability.h b/libcxx/include/__configuration/availability.h
-index 263efe7ea397..baad76af3716 100644
+index 004ea005a160..f394a5c51f96 100644
 --- a/libcxx/include/__configuration/availability.h
 +++ b/libcxx/include/__configuration/availability.h
-@@ -337,8 +337,8 @@
+@@ -317,8 +317,8 @@
  // These macros controls the availability of __cxa_init_primary_exception
  // in the built library, which std::make_exception_ptr might use
  // (see libcxx/include/__exception/exception_ptr.h).
@@ -27,6 +27,6 @@ index 263efe7ea397..baad76af3716 100644
 -#define _LIBCPP_AVAILABILITY_INIT_PRIMARY_EXCEPTION _LIBCPP_INTRODUCED_IN_LLVM_18_ATTRIBUTE
 +#define _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION 0
 +#define _LIBCPP_AVAILABILITY_INIT_PRIMARY_EXCEPTION /* nothing */
- 
+
  // This controls the availability of C++23 <print>, which
  // has a dependency on the built library (it needs access to

--- a/recipe/patches/0002-Work-around-stray-nostdlib-flags-causing-errors-with.patch
+++ b/recipe/patches/0002-Work-around-stray-nostdlib-flags-causing-errors-with.patch
@@ -1,7 +1,7 @@
-From 3dca18c4a50662aa8b9ed0107b2c6f63adcb552c Mon Sep 17 00:00:00 2001
+From a2f2655ba6726bd01d23b2cbabc4bd52e20376d4 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Sun, 26 May 2024 13:01:28 +1100
-Subject: [PATCH 4/5] Work around stray `-nostdlib++` flags causing errors with
+Subject: [PATCH 4/6] Work around stray `-nostdlib++` flags causing errors with
  C compiler
 
 ---
@@ -29,10 +29,10 @@ index 10f2087c68c5..c0e58f8b255c 100644
      LIBCXXABI_HAS_CXA_THREAD_ATEXIT_IMPL)
  endif()
 diff --git a/libunwind/cmake/config-ix.cmake b/libunwind/cmake/config-ix.cmake
-index 126c872f0d48..ab9ea1d5ce01 100644
+index d42ceffb1f63..eab194cf73df 100644
 --- a/libunwind/cmake/config-ix.cmake
 +++ b/libunwind/cmake/config-ix.cmake
-@@ -120,8 +120,11 @@ if(FUCHSIA)
+@@ -64,8 +64,11 @@ if(FUCHSIA)
    set(LIBUNWIND_HAS_DL_LIB NO)
    set(LIBUNWIND_HAS_PTHREAD_LIB NO)
  else()
@@ -44,13 +44,13 @@ index 126c872f0d48..ab9ea1d5ce01 100644
 +  set(LIBUNWIND_HAS_DL_LIB YES)
 +  set(LIBUNWIND_HAS_PTHREAD_LIB YES)
  endif()
- 
+
  if(HAIKU)
 diff --git a/libunwind/src/CMakeLists.txt b/libunwind/src/CMakeLists.txt
-index ecbd019bb29e..0d8128593684 100644
+index 71663a22cdf4..858c343c70b4 100644
 --- a/libunwind/src/CMakeLists.txt
 +++ b/libunwind/src/CMakeLists.txt
-@@ -180,7 +180,8 @@ set_target_properties(unwind_shared
+@@ -153,7 +153,8 @@ set_target_properties(unwind_shared
    PROPERTIES
      EXCLUDE_FROM_ALL "$<IF:$<BOOL:${LIBUNWIND_ENABLE_SHARED}>,FALSE,TRUE>"
      LINK_FLAGS "${LIBUNWIND_LINK_FLAGS}"
@@ -60,7 +60,7 @@ index ecbd019bb29e..0d8128593684 100644
      OUTPUT_NAME "${LIBUNWIND_SHARED_OUTPUT_NAME}"
      VERSION     "${LIBUNWIND_LIBRARY_VERSION}"
      SOVERSION   "1"
-@@ -227,7 +228,8 @@ set_target_properties(unwind_static
+@@ -201,7 +202,8 @@ set_target_properties(unwind_static
    PROPERTIES
      EXCLUDE_FROM_ALL "$<IF:$<BOOL:${LIBUNWIND_ENABLE_STATIC}>,FALSE,TRUE>"
      LINK_FLAGS "${LIBUNWIND_LINK_FLAGS}"
@@ -69,4 +69,3 @@ index ecbd019bb29e..0d8128593684 100644
 +    LINKER_LANGUAGE CXX
      OUTPUT_NAME "${LIBUNWIND_STATIC_OUTPUT_NAME}"
  )
- 

--- a/recipe/patches/0003-patch-__libcpp_tzdb_directory-to-allow-use-on-osx.patch
+++ b/recipe/patches/0003-patch-__libcpp_tzdb_directory-to-allow-use-on-osx.patch
@@ -1,14 +1,14 @@
-From dc24e891f067f9bbc34c8c8e6e66d10b0c02cd33 Mon Sep 17 00:00:00 2001
+From 0a9f7ddc1ac5d65185c276907fb66e4e46dba39f Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 31 Jul 2024 14:57:49 +1100
-Subject: [PATCH 5/5] patch __libcpp_tzdb_directory to allow use on osx
+Subject: [PATCH 5/6] patch __libcpp_tzdb_directory to allow use on osx
 
 ---
  libcxx/src/experimental/tzdb.cpp | 4 ----
  1 file changed, 4 deletions(-)
 
 diff --git a/libcxx/src/experimental/tzdb.cpp b/libcxx/src/experimental/tzdb.cpp
-index f38f495c2d0b..8cc6f3309702 100644
+index ac5c62bb8190..ac85cffe465a 100644
 --- a/libcxx/src/experimental/tzdb.cpp
 +++ b/libcxx/src/experimental/tzdb.cpp
 @@ -52,11 +52,7 @@ namespace chrono {
@@ -21,5 +21,5 @@ index f38f495c2d0b..8cc6f3309702 100644
 -#  error "unknown path to the IANA Time Zone Database"
 -#endif
  }
- 
+
  //===----------------------------------------------------------------------===//


### PR DESCRIPTION
libcxx 21.1.8 

  **Destination channel:** defaults

  ### Links

  - [PKG-10601](https://anaconda.atlassian.net/browse/PKG-10601)
  - [Upstream repository](https://github.com/llvm/llvm-project)
  - [Upstream changelog/diff](https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.8)
  - 
 ### Related PRs

  - AnacondaRecipes/llvmdev-feedstock#33
  - AnacondaRecipes/clangdev-feedstock#21
  - AnacondaRecipes/cctools-and-ld64-feedstock#18
  - AnacondaRecipes/clang-compiler-activation-feedstock#24
  - AnacondaRecipes/compiler-rt-feedstock#10
  - AnacondaRecipes/lld-feedstock#13
  - AnacondaRecipes/mlir-feedstock#10


  ### Explanation of changes:

  - Update version to 21.1.8
  - Update patches for LLVM 21 compatibility (from conda-forge)
  - Add abs.yaml with staging channel configuration
  - Reset build number to 0

### Note on osx-arm64 Test Phase

  The osx-arm64 **build succeeded**, but the **test phase failed** due to a temporary dependency resolution issue during staging.

  **Root cause:** The test environment requests `libcxx-devel` without specifying the staging channel. The solver finds `libcxx-devel==17.0.6` from pkgs/main (where 21.1.8 doesn't exist yet) and attempts to install it alongside the newly built `libcxx==21.1.8`, causing a version conflict.

  **This is a staging-only issue.** Once all LLVM 21 packages are promoted to pkgs/main, both `libcxx` and `libcxx-devel` 21.1.8 will be available, and the solver will resolve to matching versions.


[PKG-10601]: https://anaconda.atlassian.net/browse/PKG-10601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ