### PR TITLE
Fix LIEF parsing error on linux-aarch64 release builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,6 +159,11 @@ outputs:
   - name: libcxxabi
     build:
       skip: true  # [not linux]
+      # Workaround for LIEF <=0.16 not recognizing DT_TLSDESC_PLT ELF tag (0x6ffffef6)
+      # on aarch64 binaries. Remove when LIEF is fixed.
+      # See: https://github.com/conda/conda-build/issues/5665
+      overlinking_ignore_patterns:
+        - lib/libc++abi.so*  # [linux and aarch64]
       missing_dso_whitelist:
         - lib/libgcc_s.so.1       # [linux]
         - /lib64/libgcc_s.so.1    # [linux]


### PR DESCRIPTION
libcxx 21.1.8                                                                                    
                                                                                                   
  **Destination channel:** defaults                                                                
                                                                                                   
  ### Links                                                                                        
                                                                                                   
  - [conda-build#5665](https://github.com/conda/conda-build/issues/5665)                           
  - [Upstream repository](https://github.com/llvm/llvm-project)                                    
  - Related discussions:                                                                           
    - [oracle-instant-client-feedstock#1](https://github.com/AnacondaRecipes/oracle-instant-client-feedstock/pull/1/commits/4ef35605836c990426efd8c263616b2d5773052f)                               
    - [cuda-nvcc-impl-feedstock#5](https://github.com/AnacondaRecipes/cuda-nvcc-impl-feedstock/pull/5) 
  - Merged PR with successful CI:  [#22](https://github.com/AnacondaRecipes/libcxx-feedstock/pull/22)  
  - Failed release build graphs:                                                                   
    - https://package-build.anaconda.com/v1/graph/225be9ed-4056-409c-aa74-c3a8157b64ee             
    - https://package-build.anaconda.com/v1/graph/0e16d39a-6ee3-4071-805f-fabe0882bb87  
                                                                                                   
  ### Explanation of changes:                                                                      
                                                                                                   
  - Add `overlinking_ignore_patterns` for `lib/libc++abi.so*` on `linux and aarch64`               
  - This bypasses LIEF <=0.16's inability to parse the `DT_TLSDESC_PLT` ELF tag (0x6ffffef6) which 
  is a GNU TLS descriptor extension                                                                
  - The release build was failing with `ValueError: 1879047926 is not a valid TAG.` during         
  conda-build's linkage analysis                                                                   
  - CI builds passed intermittently because the binary content varies slightly between build       
  machines                                                                                         
  - Workaround can be removed when LIEF is updated to recognize this tag 
