### PR TITLE
Update libcxx to 22.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+# Stage 0: Upload to LLVM 22 staging channel
+staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
 aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,6 +5,7 @@ cxx_compiler:         # [osx]
 
 # libcxx only supports the last released GCC version, see
 # https://libcxx.llvm.org/index.html#platform-and-compiler-support
+# Stage 0: Bootstrap build with LLVM 21 compiler (update to 22 in Stage 2)
 c_compiler_version:
   - 11.2                # [linux]
   - 21                  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 {% set major = version.split(".")[0]|int %}
 
 {% set bootstrap_version = version %}
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-    sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
+    sha256: a252efd7a4a268d2cc5145b17adcaa82757fdee1d06d748b4c24137807710ecb
     patches:
       # disable feature that requires up-to-date libcxxabi, which we don't ship
       - patches/0001-disable-_LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPT.patch  # [osx]


### PR DESCRIPTION
## Description

Update libcxx from 21.1.8 to 22.1.2 (LLVM 22 update).

**Stage 0:** Bootstrap build using LLVM 21 compiler.

- Updated version to 22.1.2 and SHA256
- Kept `c_compiler_version: 21` for macOS (bootstrap with old compiler)
- abs.yaml targets `llvm-22.1.2-stage0-build-0` staging channel

Part of PKG-12851 (LLVM 22 epic), child ticket PKG-13332.