### PR TITLE
Update libcxx to 22.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,6 @@ build_parameters:
   - "--error-overlinking"
 
 # Stage 0: Upload to LLVM 22 staging channel
-staging_channel_upload_target: llvm-22.1.2-stage0-build-0
+staging_channel_upload_target: llvm22-stage0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+# Stage 0: Upload to LLVM 22 staging channel
+staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,9 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Stage 0: Upload to LLVM 22 staging channel
-staging_channel_upload_target: llvm22-stage0
+# Stage 2: Self-hosted build
+# All LLVM 22 packages on anaconda.org (bypass PBP staging, SIR-2834)
+channels:
+  - https://conda.anaconda.org/xkong-staging
 
 aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,6 +5,7 @@ cxx_compiler:         # [osx]
 
 # libcxx only supports the last released GCC version, see
 # https://libcxx.llvm.org/index.html#platform-and-compiler-support
+# Stage 0: Bootstrap build with LLVM 21 compiler (update to 22 in Stage 2)
 c_compiler_version:
   - 11.2                # [linux]
   - 21                  # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,10 +5,10 @@ cxx_compiler:         # [osx]
 
 # libcxx only supports the last released GCC version, see
 # https://libcxx.llvm.org/index.html#platform-and-compiler-support
-# Stage 0: Bootstrap build with LLVM 21 compiler (update to 22 in Stage 2)
+# Stage 2: Self-hosted build with clang 22
 c_compiler_version:
   - 11.2                # [linux]
-  - 21                  # [osx]
+  - 22                  # [osx]
 cxx_compiler_version:
   - 11.2                # [linux]
-  - 21                  # [osx]
+  - 22                  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set version = "22.1.2" %}
 {% set major = version.split(".")[0]|int %}
 
-# Stage 0: Use LLVM 21 to bootstrap (change back to `version` in Stage 2)
-{% set bootstrap_version = "21.1.8" %}
+# Stage 2: self-hosted build
+{% set bootstrap_version = version %}
 
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 {% set major = version.split(".")[0]|int %}
 
 {% set bootstrap_version = version %}
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-    sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
+    sha256: a252efd7a4a268d2cc5145b17adcaa82757fdee1d06d748b4c24137807710ecb
     patches:
       # disable feature that requires up-to-date libcxxabi, which we don't ship
       - patches/0001-disable-_LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPT.patch  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set version = "22.1.2" %}
 {% set major = version.split(".")[0]|int %}
 
-{% set bootstrap_version = version %}
+# Stage 0: Use LLVM 21 to bootstrap (change back to `version` in Stage 2)
+{% set bootstrap_version = "21.1.8" %}
 
 
 package:


### PR DESCRIPTION
libcxx 22.1.2

**Destination channel:** defaults

### Links

- [PKG-13332](https://anaconda.atlassian.net/browse/PKG-13332)
- [PKG-12851](https://anaconda.atlassian.net/browse/PKG-12851) (LLVM 22 epic)
- [Upstream repository](https://github.com/llvm/llvm-project)
- [Upstream changelog/diff](https://releases.llvm.org/22.1.0/docs/ReleaseNotes.html)

### Explanation of changes:

- Updated version from 21.1.8 to 22.1.2 and SHA256
- Stage 2: self-hosted build with clang 22 compiler (`c_compiler_version: 22`)
- `bootstrap_version` set to `version` (self-hosted)
- abs.yaml uses `xkong-staging` channel for LLVM 22 dependencies

**Note:** This PR uses `https://conda.anaconda.org/xkong-staging` instead of PBP staging channels because PBP staging corrupts large files (>400MB) during download — see [SIR-2834](https://anaconda.atlassian.net/browse/SIR-2834). All LLVM 22 packages were downloaded from TaskCluster artifacts and uploaded to `xkong-staging` on anaconda.org as a workaround. This channel reference should be removed after packages are promoted to pkgs/main.

[PKG-13332]: https://anaconda.atlassian.net/browse/PKG-13332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-12851]: https://anaconda.atlassian.net/browse/PKG-12851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIR-2834]: https://anaconda.atlassian.net/browse/SIR-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ